### PR TITLE
Feature/improve docker compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18
 
-LABEL version="1.8.2"
+LABEL version="1.9.0"
 LABEL description="Script written in JavaScript (Node) that uploads CGM readings from LibreLink Up to Nightscout"
 
 # Create app directory

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ work with at least Freestyle Libre 2 (FGM) and Libre 3 CGM sensors.
 
 The script takes the following environment variables
 
-| Variable              | Description                                                                                                      | Example                                  | Required |
-|-----------------------|------------------------------------------------------------------------------------------------------------------|------------------------------------------|--------|
-| LINK_UP_USERNAME      | LibreLink Up Login Email                                                                                         | mail@example.com                         | X      |
-| LINK_UP_PASSWORD      | LibreLink Up Login Password                                                                                      | mypassword                               | X      |
-| LINK_UP_CONNECTION    | LibreLink Up Patient-ID. Can be received from the console output if multiple connections are available.          | 123456abc-abcd-efgh-7891def              |        |
-| LINK_UP_TIME_INTERVAL | The time interval of requesting values from libre link up                                                        | 5                                        |        |
-| LINK_UP_REGION        | Your region. Used to determine the correct LibreLinkUp service (Possible values: US, EU, DE, FR, JP, AP, AU, AE) | EU                                       |        |
-| NIGHTSCOUT_URL        | Hostname of the Nightscout instance (without https://)                                                           | nightscout.yourdomain.com                | X      |
-| NIGHTSCOUT_API_TOKEN  | SHA1 Hash of Nightscout access token                                                                             | 162f14de46149447c3338a8286223de407e3b2fa | X      |
-| LOG_LEVEL             | The setting of verbosity for logging, should be one of info or debug                                             | info                                     | X      |
+| Variable                 | Description                                                                                                      | Example                                  | Required |
+|--------------------------|------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
+| LINK_UP_USERNAME         | LibreLink Up Login Email                                                                                         | mail@example.com                         | X        |
+| LINK_UP_PASSWORD         | LibreLink Up Login Password                                                                                      | mypassword                               | X        |
+| LINK_UP_CONNECTION       | LibreLink Up Patient-ID. Can be received from the console output if multiple connections are available.          | 123456abc-abcd-efgh-7891def              |          |
+| LINK_UP_TIME_INTERVAL    | The time interval of requesting values from libre link up                                                        | 5                                        |          |
+| LINK_UP_REGION           | Your region. Used to determine the correct LibreLinkUp service (Possible values: US, EU, DE, FR, JP, AP, AU, AE) | EU                                       |          |
+| NIGHTSCOUT_URL           | Hostname of the Nightscout instance (without https://)                                                           | nightscout.yourdomain.com                | X        |
+| NIGHTSCOUT_API_TOKEN     | SHA1 Hash of Nightscout access token                                                                             | 162f14de46149447c3338a8286223de407e3b2fa | X        |
+| NIGHTSCOUT_DISABLE_HTTPS | Disables the HTTPS requirement for Nightscout URLs                                                               | true                                     |          |
+| LOG_LEVEL                | The setting of verbosity for logging, should be one of info or debug                                             | info                                     |          |
+| SINGLE_SHOT              | Disables the scheduler and runs the script just once                                                             | true                                     |          |
 
 ## Usage
 

--- a/app.json
+++ b/app.json
@@ -47,10 +47,20 @@
       "value": "",
       "required": true
     },
+    "NIGHTSCOUT_DISABLE_HTTPS": {
+      "description": "Disables the HTTPS requirement for Nightscout URLs",
+      "value": "",
+      "required": false
+    },
     "LOG_LEVEL": {
       "description": "The log-level to use.",
       "value": "info",
-      "required": true
+      "required": false
+    },
+    "SINGLE_SHOT": {
+      "description": "Disables the scheduler and runs the script just once",
+      "value": "",
+      "required": false
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nightscout-librelink-up",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -203,9 +203,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-stable-stringify": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
+      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -249,10 +249,11 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "winston": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
-      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
       "requires": {
+        "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightscout-librelink-up",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Script written in JavaScript (Node) that uploads CGM readings from LibreLink Up to Nightscout",
   "main": "index.js",
   "scripts": {
@@ -33,6 +33,6 @@
   "dependencies": {
     "axios": "^0.27.2",
     "node-cron": "3.0.2",
-    "winston": "^3.8.1"
+    "winston": "^3.8.2"
   }
 }


### PR DESCRIPTION
What happened in this update: 

### "Single shot" mode
When setting the environment variable "SINGLE_SHOT" to ´true´ the builtin scheduler will be disabled and the script runs just once and exits after completion. This is very useful if you want to use your own scheduler. 

### Disabling of HTTPS for Nightscout
Until now, the `https://` prefix was hard-coded into the URL of the Nightscout instance. Although HTTPS encryption is very important and should be the default, there are deployments where disabling this it me required. A very good use-case for disabling HTTPS has been provided in #68. The new environment variable `NIGHTSCOUT_DISABLE_HTTPS` allows this behavior to be enabled.

### Minor improvements
- The script no longer tries to upload 0 measurements to Nightscout
- Updated to the lastest `winston` dependency