### PR TITLE
Feature: LLU compatibility update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Timo Schlüter
+Copyright (c) 2021, 2022, 2023 Timo Schlüter <timo.schlueter@me.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ work with at least Freestyle Libre 2 (FGM) and Libre 3 CGM sensors.
 
 The script takes the following environment variables
 
-| Variable                 | Description                                                                                                      | Example                                  | Required |
-|--------------------------|------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
-| LINK_UP_USERNAME         | LibreLink Up Login Email                                                                                         | mail@example.com                         | X        |
-| LINK_UP_PASSWORD         | LibreLink Up Login Password                                                                                      | mypassword                               | X        |
-| LINK_UP_CONNECTION       | LibreLink Up Patient-ID. Can be received from the console output if multiple connections are available.          | 123456abc-abcd-efgh-7891def              |          |
-| LINK_UP_TIME_INTERVAL    | The time interval of requesting values from libre link up                                                        | 5                                        |          |
-| LINK_UP_REGION           | Your region. Used to determine the correct LibreLinkUp service (Possible values: US, EU, DE, FR, JP, AP, AU, AE) | EU                                       |          |
-| NIGHTSCOUT_URL           | Hostname of the Nightscout instance (without https://)                                                           | nightscout.yourdomain.com                | X        |
-| NIGHTSCOUT_API_TOKEN     | SHA1 Hash of Nightscout access token                                                                             | 162f14de46149447c3338a8286223de407e3b2fa | X        |
-| NIGHTSCOUT_DISABLE_HTTPS | Disables the HTTPS requirement for Nightscout URLs                                                               | true                                     |          |
-| NIGHTSCOUT_DEVICE_NAME   | Sets the device name used in Nightscout                                                                          | nightscout-librelink-up                  |          |
-| LOG_LEVEL                | The setting of verbosity for logging, should be one of info or debug                                             | info                                     |          |
-| SINGLE_SHOT              | Disables the scheduler and runs the script just once                                                             | true                                     |          |
+| Variable                 | Description                                                                                                                | Example                                  | Required |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
+| LINK_UP_USERNAME         | LibreLink Up Login Email                                                                                                   | mail@example.com                         | X        |
+| LINK_UP_PASSWORD         | LibreLink Up Login Password                                                                                                | mypassword                               | X        |
+| LINK_UP_CONNECTION       | LibreLink Up Patient-ID. Can be received from the console output if multiple connections are available.                    | 123456abc-abcd-efgh-7891def              |          |
+| LINK_UP_TIME_INTERVAL    | The time interval of requesting values from libre link up                                                                  | 5                                        |          |
+| LINK_UP_REGION           | Your region. Used to determine the correct LibreLinkUp service (Possible values: AE, AP, AU, CA, DE, EU2, EU2, FR, JP, US) | EU                                       |          |
+| NIGHTSCOUT_URL           | Hostname of the Nightscout instance (without https://)                                                                     | nightscout.yourdomain.com                | X        |
+| NIGHTSCOUT_API_TOKEN     | SHA1 Hash of Nightscout access token                                                                                       | 162f14de46149447c3338a8286223de407e3b2fa | X        |
+| NIGHTSCOUT_DISABLE_HTTPS | Disables the HTTPS requirement for Nightscout URLs                                                                         | true                                     |          |
+| NIGHTSCOUT_DEVICE_NAME   | Sets the device name used in Nightscout                                                                                    | nightscout-librelink-up                  |          |
+| LOG_LEVEL                | The setting of verbosity for logging, should be one of info or debug                                                       | info                                     |          |
+| SINGLE_SHOT              | Disables the scheduler and runs the script just once                                                                       | true                                     |          |
 
 ## Usage
 

--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       "required": true
     },
     "LINK_UP_REGION": {
-      "description": "Your region. Used to determine the correct LibreLinkUp service (Possible values: US, EU, DE, FR, JP, AP, AU, AE)",
+      "description": "Your region. Used to determine the correct LibreLinkUp service (Possible values: AE, AP, AU, CA, DE, EU2, EU2, FR, JP, US)",
       "value": "EU",
       "required": false
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nightscout-librelink-up",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nightscout-librelink-up",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightscout-librelink-up",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ const LINK_UP_PASSWORD = process.env.LINK_UP_PASSWORD;
 /**
  * LibreLink Up API Settings (Don't change this unless you know what you are doing)
  */
-const LIBRE_LINK_UP_VERSION = "4.2.2";
+const LIBRE_LINK_UP_VERSION = "4.7.0";
 const LIBRE_LINK_UP_PRODUCT = "llu.ios";
 const LINK_UP_REGION = process.env.LINK_UP_REGION || "EU";
 const LIBRE_LINK_UP_URL = getLibreLinkUpUrl(LINK_UP_REGION);


### PR DESCRIPTION
Since version 4.7.0 of the LibreLink Up App has been released to the public app stores by Abbott, all information necessary to keep _nightscout-librelink-up_ running has been made available. Analysing the traffic between a freshly installed LLU app showed that the only differences in the 4.7.0 update are:

- The `version` HTTP request header field is set to 4.7.0 after the update
- The REST endpoint to receive all available API-/Region-Information now.takes two GET-Paramters (`country` and `version`) and sends a response that is the same as with older version. Only the GET-Parameters have been added. Since this endpoint is not used by this app, this is just for documentation purposes: `https://api.libreview.io/llu/config/country?country=DE&version=4.7.0`

This PR updates the version to 4.7.0 and otherwise fixes just a few documentation problems.

See also #99 and #97 