### PR TITLE
Bugfix: Docker build pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18-bullseye
 LABEL description="Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout"
 
 # Create app directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nightscout-librelink-up",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nightscout-librelink-up",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightscout-librelink-up",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
There seem to be issues associated with building multiple containers without explicitly specifying which version of node is used for a docker image: https://github.com/nodejs/node/issues/43064#issuecomment-1591237820

This PR sets the base-image for the container to a specific version.