### PR TITLE
Make `readConfig` source of truth

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,22 +1,60 @@
+import { LLU_API_ENDPOINTS } from './constants/llu-api-endpoints';
+
 function readConfig() {
-	const requiredEnvs = ['NIGHTSCOUT_API_TOKEN', 'NIGHTSCOUT_URL'];
+	const requiredEnvs = [
+		'NIGHTSCOUT_API_TOKEN',
+		'NIGHTSCOUT_URL',
+		'LINK_UP_USERNAME',
+		'LINK_UP_PASSWORD',
+	];
 	for (let envName of requiredEnvs) {
 		if (!process.env[envName]) {
-			throw Error(`Required environment variable ${envName} is not set`);
+			exitLog(`Required environment variable ${envName} is not set`)
 		}
 	}
 
-	const protocol =
+	if (process.env.LOG_LEVEL) {
+        if (!['info', 'debug'].includes(process.env.LOG_LEVEL.toLowerCase())) {
+			exitLog(`LOG_LEVEL should be either 'info' or 'debug', but got '${process.env.LOG_LEVEL}'`);
+        }
+    }
+    if (process.env.LINK_UP_REGION) {
+        if (!LLU_API_ENDPOINTS.hasOwnProperty(process.env.LINK_UP_REGION)) {
+            exitLog(`LINK_UP_REGION should be one of ${Object.keys(LLU_API_ENDPOINTS)}, but got ${process.env.LINK_UP_REGION}`);
+        }
+    }
+    if (process.env.LINK_UP_TIME_INTERVAL) {
+        if (isNaN(parseInt(process.env.LINK_UP_TIME_INTERVAL))) {
+            exitLog(`LINK_UP_TIME_INTERVAL expected to be an integer, but got '${process.env.LINK_UP_TIME_INTERVAL}'`);
+        }
+    }
+
+    const protocol =
 		process.env.NIGHTSCOUT_DISABLE_HTTPS === 'true' ? 'http://' : 'https://';
 	const url = new URL(protocol + process.env.NIGHTSCOUT_URL);
 
 	return {
 		nightscoutApiToken: process.env.NIGHTSCOUT_API_TOKEN as string,
-		nightscoutBaseUrl: url.toString(),
+        nightscoutBaseUrl: url.toString(),
+        linkUpUsername: process.env.LINK_UP_USERNAME as string,
+        linkUpPassword: process.env.LINK_UP_PASSWORD as string,
 
-		nightscoutApiV3: process.env.NIGHTSCOUT_API_V3 === 'true',
-		nightscoutDevice: process.env.DEVICE_NAME || 'nightscout-librelink-up',
+        logLevel: process.env.LOG_LEVEL || 'info',
+        singleShot: process.env.SINGLE_SHOT === 'true',
+
+        nightscoutApiV3: process.env.NIGHTSCOUT_API_V3 === 'true',
+        nightscoutDisableHttps: process.env.NIGHTSCOUT_DISABLE_HTTPS === 'true',
+        nightscoutDevice: process.env.DEVICE_NAME || 'nightscout-librelink-up',
+
+        linkUpRegion: process.env.LINK_UP_REGION || 'EU',
+        linkUpTimeInterval: Number(process.env.LINK_UP_TIME_INTERVAL) || 5,
+        linkUpConnection: process.env.LINK_UP_CONNECTION as string,
 	};
+}
+
+function exitLog(msg: string) {
+	console.log(msg);
+	process.exit(1);
 }
 
 export default readConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,41 +14,41 @@ function readConfig() {
 	}
 
 	if (process.env.LOG_LEVEL) {
-        if (!['info', 'debug'].includes(process.env.LOG_LEVEL.toLowerCase())) {
+		if (!['info', 'debug'].includes(process.env.LOG_LEVEL.toLowerCase())) {
 			exitLog(`LOG_LEVEL should be either 'info' or 'debug', but got '${process.env.LOG_LEVEL}'`);
-        }
-    }
-    if (process.env.LINK_UP_REGION) {
-        if (!LLU_API_ENDPOINTS.hasOwnProperty(process.env.LINK_UP_REGION)) {
-            exitLog(`LINK_UP_REGION should be one of ${Object.keys(LLU_API_ENDPOINTS)}, but got ${process.env.LINK_UP_REGION}`);
-        }
-    }
-    if (process.env.LINK_UP_TIME_INTERVAL) {
-        if (isNaN(parseInt(process.env.LINK_UP_TIME_INTERVAL))) {
-            exitLog(`LINK_UP_TIME_INTERVAL expected to be an integer, but got '${process.env.LINK_UP_TIME_INTERVAL}'`);
-        }
-    }
+		}
+	}
+	if (process.env.LINK_UP_REGION) {
+		if (!LLU_API_ENDPOINTS.hasOwnProperty(process.env.LINK_UP_REGION)) {
+			exitLog(`LINK_UP_REGION should be one of ${Object.keys(LLU_API_ENDPOINTS)}, but got ${process.env.LINK_UP_REGION}`);
+		}
+	}
+	if (process.env.LINK_UP_TIME_INTERVAL) {
+		if (isNaN(parseInt(process.env.LINK_UP_TIME_INTERVAL))) {
+			exitLog(`LINK_UP_TIME_INTERVAL expected to be an integer, but got '${process.env.LINK_UP_TIME_INTERVAL}'`);
+		}
+	}
 
-    const protocol =
+	const protocol =
 		process.env.NIGHTSCOUT_DISABLE_HTTPS === 'true' ? 'http://' : 'https://';
 	const url = new URL(protocol + process.env.NIGHTSCOUT_URL);
 
 	return {
 		nightscoutApiToken: process.env.NIGHTSCOUT_API_TOKEN as string,
-        nightscoutBaseUrl: url.toString(),
-        linkUpUsername: process.env.LINK_UP_USERNAME as string,
-        linkUpPassword: process.env.LINK_UP_PASSWORD as string,
+		nightscoutBaseUrl: url.toString(),
+		linkUpUsername: process.env.LINK_UP_USERNAME as string,
+		linkUpPassword: process.env.LINK_UP_PASSWORD as string,
 
-        logLevel: process.env.LOG_LEVEL || 'info',
-        singleShot: process.env.SINGLE_SHOT === 'true',
+		logLevel: process.env.LOG_LEVEL || 'info',
+		singleShot: process.env.SINGLE_SHOT === 'true',
 
-        nightscoutApiV3: process.env.NIGHTSCOUT_API_V3 === 'true',
-        nightscoutDisableHttps: process.env.NIGHTSCOUT_DISABLE_HTTPS === 'true',
-        nightscoutDevice: process.env.DEVICE_NAME || 'nightscout-librelink-up',
+		nightscoutApiV3: process.env.NIGHTSCOUT_API_V3 === 'true',
+		nightscoutDisableHttps: process.env.NIGHTSCOUT_DISABLE_HTTPS === 'true',
+		nightscoutDevice: process.env.DEVICE_NAME || 'nightscout-librelink-up',
 
-        linkUpRegion: process.env.LINK_UP_REGION || 'EU',
-        linkUpTimeInterval: Number(process.env.LINK_UP_TIME_INTERVAL) || 5,
-        linkUpConnection: process.env.LINK_UP_CONNECTION as string,
+		linkUpRegion: process.env.LINK_UP_REGION || 'EU',
+		linkUpTimeInterval: Number(process.env.LINK_UP_TIME_INTERVAL) || 5,
+		linkUpConnection: process.env.LINK_UP_CONNECTION as string,
 	};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ import {HttpCookieAgent} from "http-cookie-agent/http";
 import {Agent as HttpAgent} from "node:http";
 import {Agent as HttpsAgent} from "node:https";
 import * as crypto from "crypto";
-import { isNativeError } from "node:util/types";
 
 // Generate new Cyphers for stealth mode in order to bypass SSL fingerprinting used by Cloudflare.
 // The new Cyphers are then used in the HTTPS Agent for Axios.
@@ -79,16 +78,7 @@ const USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_5_1 like Mac OS X) App
  */
 const LIBRE_LINK_UP_VERSION = "4.7.0";
 const LIBRE_LINK_UP_PRODUCT = "llu.ios";
-const LIBRE_LINK_UP_URL = getLibreLinkUpUrl(config.linkUpRegion);
-
-function getLibreLinkUpUrl(region: string): string
-{
-    if (LLU_API_ENDPOINTS.hasOwnProperty(region))
-    {
-        return LLU_API_ENDPOINTS[region];
-    }
-    return LLU_API_ENDPOINTS.EU;
-}
+const LIBRE_LINK_UP_URL = LLU_API_ENDPOINTS[config.linkUpRegion];
 
 /**
  * last known authTicket
@@ -140,7 +130,7 @@ async function main(): Promise<void>
     }
 
     await uploadToNightScout(glucoseGraphData);
-}
+    }
 
 export async function login(): Promise<AuthTicket | null>
 {
@@ -311,7 +301,7 @@ export async function createFormattedMeasurements(measurementData: GraphData): P
 async function uploadToNightScout(measurementData: GraphData): Promise<void>
 {
     const formattedMeasurements: Entry[] = await createFormattedMeasurements(measurementData);
-
+    
     if (formattedMeasurements.length > 0)
     {
         logger.info("Trying to upload " + formattedMeasurements.length + " glucose measurement items to Nightscout");


### PR DESCRIPTION
Hi there,

- I've added more logic into `readConfig` function. It now validates more values. 
  - `readConfig` now makes `os.exit` instead of throwing an error, because I think a short message `Required environment variable LINK_UP_USERNAME is not set` is more readable in the output than the same message AND stacktrace.
- I also removed any `process.env.*` from index.ts thus making config object the source of truth for configuration