### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git*
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ COPY . /usr/src/app
 RUN npm run test ; \
     rm -r tests coverage
 
+# Compile
+RUN npm run build
+
+# Remove devel-only dependencies
+RUN npm prune --omit dev
+
 FROM node:20-bookworm-slim
 LABEL description="Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout"
 
@@ -22,4 +28,4 @@ COPY --from=build-stage /usr/src/app /usr/src/app
 
 WORKDIR /usr/src/app
 
-CMD [ "npm", "start" ]
+CMD [ "npm", "run", "start-heroku" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm
+FROM node:20-bookworm-slim
 LABEL description="Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout"
 
 # Create app directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:20-bookworm-slim
-LABEL description="Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout"
+FROM node:20-bookworm-slim AS build-stage
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -13,9 +12,14 @@ RUN npm install
 COPY . /usr/src/app
 
 # Run tests
-RUN npm run test
+RUN npm run test ; \
+    rm -r tests coverage
 
-RUN rm -r tests
-RUN rm -r coverage
+FROM node:20-bookworm-slim
+LABEL description="Script written in TypeScript that uploads CGM readings from LibreLink Up to Nightscout"
+
+COPY --from=build-stage /usr/src/app /usr/src/app
+
+WORKDIR /usr/src/app
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
# Docker image reduction

This PR reduces the Docker image size massively while remaining on Debian Bookworm, as far as I can tell there should be no ill effects. Below are my comparisons.

Each step was rebuilt to ease comparison with:
```shell
docker build -t librelink-up-pr .
```
And they include the changes from previous steps.

Sizes are compared with:
```shell
docker image ls | grep librelink | awk '{print $NF,$1}'
```

Also a `.dockerignore` file is included to avoid copying the git-related files and directories into the image.

## Starting point

~~~
1.51GB librelink-up-pr
1.51GB timoschlueter/nightscout-librelink-up
~~~

## Switch to node:20-bookworm-slim as base image

~~~
618MB librelink-up-pr
1.51GB timoschlueter/nightscout-librelink-up
~~~

## Use a separate builder stage

~~~
277MB librelink-up-pr
1.51GB timoschlueter/nightscout-librelink-up
~~~

## Remove devDependencies

This also involves pre-compiling the TypeScript code

~~~
204MB librelink-up-pr
1.51GB timoschlueter/nightscout-librelink-up
~~~