### PR TITLE
Added ALL_DATA configuration option to allow uploading all available historic data to Nightscout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The script takes the following environment variables
 | NIGHTSCOUT_DEVICE_NAME   | Sets the device name used in Nightscout                                                                                    | nightscout-librelink-up                  |          |
 | LOG_LEVEL                | The setting of verbosity for logging, should be one of info or debug                                                       | info                                     |          |
 | SINGLE_SHOT              | Disables the scheduler and runs the script just once                                                                       | true                                     |          |
+| ALL_DATA                 | Upload all available data from LibreLink Up instead of just data newer than last upload. LibreLinkUp sometimes lags behind in reporting recent historical data, so it is advised to run the script with ALL_DATA set to true at least once a day.                         | true                                     |          |
 
 ## Usage
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,7 @@ function readConfig()
 
         logLevel: process.env.LOG_LEVEL || 'info',
         singleShot: process.env.SINGLE_SHOT === 'true',
+	allData: process.env.ALL_DATA === 'true',
 
         nightscoutApiV3: process.env.NIGHTSCOUT_API_V3 === 'true',
         nightscoutDisableHttps: process.env.NIGHTSCOUT_DISABLE_HTTPS === 'true',

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,8 +285,7 @@ export async function createFormattedMeasurements(measurementData: GraphData): P
     const formattedMeasurements: Entry[] = [];
     const glucoseMeasurement = measurementData.connection.glucoseMeasurement;
     const measurementDate = getUtcDateFromString(glucoseMeasurement.FactoryTimestamp);
-    const lastEntry = await nightscoutClient.lastEntry();
-
+    const lastEntry = config.allData ? null : await nightscoutClient.lastEntry();
     // Add the most recent measurement first
     if (lastEntry === null || measurementDate > lastEntry.date)
     {


### PR DESCRIPTION
Librelink Up sometimes lags behind in reporting historical values, i.e. it reports the current CGM reading and those dating more than 30 minutes back, but not the ones that were collected within the last 30 minutes.

ALL_DATA=true now gets nightscout-linklink-up to resend all historic data to nightscout. Nightscout seems to detect duplicate data, so re-uploading data that nighscout already knows about is not a problem.

I run the script with ALL_DATA=true once an hour in addition to using cron to run it every minute.