### PR TITLE
Update llu-api-endpoints.ts

### DIFF
--- a/src/constants/llu-api-endpoints.ts
+++ b/src/constants/llu-api-endpoints.ts
@@ -13,4 +13,5 @@ export const LLU_API_ENDPOINTS: LluApiEndpoints = {
     FR: "api-fr.libreview.io",
     JP: "api-jp.libreview.io",
     US: "api-us.libreview.io",
+    LA: "api-la.libreview.io",
 } as const;


### PR DESCRIPTION
Abbott includes a new API endpoint, with LA location.

This pull request is to include `LA: "api-la.libreview.io"` in [llu-api-endpoints.ts](https://github.com/timoschlueter/nightscout-librelink-up/blob/e84040f8dc07f4ebdc068fe2b21d57a01aff5808/src/constants/llu-api-endpoints.ts) file.

